### PR TITLE
Updated Marker style

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -85,15 +85,16 @@ function setupMarkersByMood(map, mood) {//Creates and places markers based on mo
           //Create a DOM element for place name
           let name = document.createElement('p');
           name.className = 'placeName';
-          name.innerHTML = place; //placesObj[place].name
           el.appendChild(name);//TODO: Have the 'name' appear on top of everything
 
           el.addEventListener('mouseenter', () => {
             $(name).toggleClass('hovered');
+            name.innerHTML = place; //placesObj[place].name
           })
 
           el.addEventListener('mouseleave', () => {
             $(name).toggleClass('hovered');
+            name.innerHTML = '';
           })
 
           el.addEventListener('click', function() {

--- a/style/map.css
+++ b/style/map.css
@@ -13,7 +13,7 @@ html, body {
   width: 30px;
   height: 30px;
   display: block;
-  border: none;
+  border: 2px solid black;
   border-radius: 50%;
   cursor: pointer;
   padding: 0;
@@ -45,4 +45,7 @@ html, body {
 
 .placeName.hovered {
   opacity: 1;
+  top: 0%;
+  border-top-left-radius: 10%;
+  border-top-right-radius: 10%;
 }


### PR DESCRIPTION
1. Name is now on top (to leave space for future menu -> information and settings);

2. `<p>` text is now generated only on mouse over. Before, a user would trigger the `marker:hover` when the cursor was on top of the invisible `<p>`. Now it's empty so that can't happen.
**I.e. users can't trigger `marker:hover` unless they hover on a marker.**