### PR TITLE
Can add/remove moods from places

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,6 +223,35 @@
 							$('.liked-yes').removeClass('btn-success')
 						}
 					})
+	function updateMood(mood) {
+		$(`#${mood}`).on('click', e => {
+			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
+			let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
+			if(data[zone][0][place]["mood"].hasOwnProperty(mood)) {
+				delete data[zone][0][place]["mood"][mood];
+				$(e.target).closest('.modal-mood').removeClass('hovered');
+				$(e.target).closest('.modal-mood').css('background', 'rgba(222, 20, 20, 0.5)')
+				$(e.target).closest('.modal-mood').mouseleave(e => {
+					$(e.target).removeAttr('style');
+				})
+			} else {
+				data[zone][0][place]["mood"][mood] = 1;
+				$(e.target).closest('.modal-mood').addClass('hovered');
+				$(e.target).closest('.modal-mood').css('background', 'rgba(20, 222, 20, 0.5)')
+				$(e.target).closest('.modal-mood').mouseleave(e => {
+					$(e.target).removeAttr('style');
+				})
+			}
+			localStorage.setItem('data', JSON.stringify(data))
+		})
+	}
+
+	updateMood("adventurous");
+	updateMood("sad");
+	updateMood("romantic");
+	updateMood("hungry");
+	updateMood("tired");
+	updateMood("creative");
 	</script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -161,7 +161,6 @@
 	<!-- Modal Script -->
 	<script type="text/javascript">
 	$('.visited-yes').on('click', e => {
-			data = JSON.parse(localStorage.getItem('data')) || json;
 			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 			let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
 			data[zone][0][place].isVisited = 'yes';
@@ -177,7 +176,6 @@
 		})
 
 		$('.visited-no').on('click', e => {
-				data = JSON.parse(localStorage.getItem('data')) || json;
 				let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 				let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
 				data[zone][0][place].isVisited = 'no';
@@ -193,7 +191,6 @@
 			})
 
 			$('.liked-yes').on('click', e => {
-					data = JSON.parse(localStorage.getItem('data')) || json;
 					let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 					let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
 					data[zone][0][place].isVisited = 'yes';
@@ -209,7 +206,6 @@
 				})
 
 				$('.liked-no').on('click', e => {
-						data = JSON.parse(localStorage.getItem('data')) || json;
 						let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 						let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
 						data[zone][0][place].isLiked = 'no';

--- a/index.html
+++ b/index.html
@@ -160,13 +160,15 @@
 
 	<!-- Modal Script -->
 	<script type="text/javascript">
-	$('.visited-yes').on('click', e => {
+
+	function updateStat(stat, elem, value) {
+		$(elem).on('click', e => {
 			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 			let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
-			data[zone][0][place].isVisited = 'yes';
+			data[zone][0][place][stat] = value;
 			localStorage.setItem('data', JSON.stringify(data))
 
-			if(data[zone][0][place].isVisited === "yes") {//Checks from data if place has been visited and modifies the UI accordingly
+			if(data[zone][0][place][stat] === "yes") {//Checks from data if place has been visited and modifies the UI accordingly
 				$('.visited-yes').addClass('btn-success')
 				$('.visited-no').removeClass('btn-danger')
 			} else {
@@ -174,51 +176,14 @@
 				$('.visited-yes').removeClass('btn-danger')
 			}
 		})
+	}
 
-		$('.visited-no').on('click', e => {
-				let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
-				let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
-				data[zone][0][place].isVisited = 'no';
-				localStorage.setItem('data', JSON.stringify(data))
+	updateStat("isVisited", ".visited-yes", "yes");
+	updateStat("isVisited", ".visited-no", "no");
+	updateStat("isLiked", ".liked-yes", "yes");
+	updateStat("isLiked", ".liked-no", "no");
 
-				if(data[zone][0][place].isVisited === "yes") {//Checks from data if place has been visited and modifies the UI accordingly
-					$('.visited-yes').addClass('btn-success')
-					$('.visited-no').removeClass('btn-danger')
-				} else {
-					$('.visited-no').addClass('btn-danger')
-					$('.visited-yes').removeClass('btn-success')
-				}
-			})
 
-			$('.liked-yes').on('click', e => {
-					let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
-					let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
-					data[zone][0][place].isVisited = 'yes';
-					localStorage.setItem('data', JSON.stringify(data))
-
-					if(data[zone][0][place].isVisited === "yes") {//Checks from data if place has been visited and modifies the UI accordingly
-						$('.liked-yes').addClass('btn-success')
-						$('.liked-no').removeClass('btn-danger')
-					} else {
-						$('.liked-no').addClass('btn-danger')
-						$('.liked-yes').removeClass('btn-danger')
-					}
-				})
-
-				$('.liked-no').on('click', e => {
-						let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
-						let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
-						data[zone][0][place].isLiked = 'no';
-						localStorage.setItem('data', JSON.stringify(data))
-
-						if(data[zone][0][place].isLiked === "yes") {//Checks from data if place has been visited and modifies the UI accordingly
-							$('.liked-yes').addClass('btn-success')
-							$('.liked-no').removeClass('btn-danger')
-						} else {
-							$('.liked-no').addClass('btn-danger')
-							$('.liked-yes').removeClass('btn-success')
-						}
-					})
 	function updateMood(mood) {
 		$(`#${mood}`).on('click', e => {
 			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')

--- a/index.html
+++ b/index.html
@@ -149,8 +149,7 @@
 				</p>
 			</div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Done</button>
       </div>
     </div>
   </div>

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -148,17 +148,6 @@ function setupMarkersByMood(map, mood) {//Creates and places markers based on mo
             icons.style.display = 'none'
           })
 
-          el.addEventListener('click', () => {
-            //Show React modal
-          });
-
-          settings.addEventListener('click', () => {
-            //Opens settings modal
-          })
-
-          showPlaceInfo.addEventListener('click', () => {
-            //Opens single place page
-          })
 
           //Add marker to map
           let curMarker = new mapboxgl.Marker({

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -121,11 +121,13 @@ function setupMarkersByMood(map, mood) {//Creates and places markers based on mo
               $('.liked-yes').removeClass('btn-success')
             }
 
+            /* Resets hovered moods */
+            $('.grid-container-modal a').each((idx, el) => {
+              $(el).removeClass('hovered')
+            })
+            /* Turns on active moods */
             Object.keys(moods).forEach(singleMood => {
-              $(`#${singleMood}`).addClass('hovered')
-              $('#modal-mood a').each((idx, el) => {
-                $(el).removeClass('hovered')
-              })
+              $(`#${singleMood}`).addClass('hovered');
             })
 
           })


### PR DESCRIPTION
- Users can now add/remove moods from a place's setting modal just by clicking on it.

This lead to the realisation that we need a button to show all places:
If a place has only "Adventurous" and we remove that, the place gets lost in the limbo of lost places.
.. Oooor, we can simply limit each place to have at least 1 mood. I prefer the latter, will discuss with team members.

- Code cleanup
- Added functions to remove redundant code
- Fixed bug in which the modal was not showing the correct moods for each place