### PR TITLE
Improved mood filter 

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,6 +215,11 @@
 				$('.mood-error').css('display', 'none') //Hide the error message
 			}
 
+			$('.modal-content').mousemove(() => {
+				$(target).removeAttr('style');
+			})
+
+
 			localStorage.setItem('data', JSON.stringify(data))
 		})
 	}

--- a/index.html
+++ b/index.html
@@ -162,27 +162,27 @@
 	<!-- Modal Script -->
 	<script type="text/javascript">
 
-	function updateStat(stat, elem, value) {
-		$(elem).on('click', e => {
+	function updateStat(stat, query, elemY, elemN, value) {
+		$(query).on('click', e => {
 			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 			let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
 			data[zone][0][place][stat] = value;
 			localStorage.setItem('data', JSON.stringify(data))
 
 			if(data[zone][0][place][stat] === "yes") {//Checks from data if place has been visited and modifies the UI accordingly
-				$('.visited-yes').addClass('btn-success')
-				$('.visited-no').removeClass('btn-danger')
+				$(elemY).addClass('btn-success')
+				$(elemN).removeClass('btn-danger')
 			} else {
-				$('.visited-no').addClass('btn-danger')
-				$('.visited-yes').removeClass('btn-danger')
+				$(elemN).addClass('btn-danger')
+				$(elemY).removeClass('btn-success')
 			}
 		})
 	}
 
-	updateStat("isVisited", ".visited-yes", "yes");
-	updateStat("isVisited", ".visited-no", "no");
-	updateStat("isLiked", ".liked-yes", "yes");
-	updateStat("isLiked", ".liked-no", "no");
+	updateStat("isVisited",  ".visited-yes", ".visited-yes", ".visited-no", "yes");
+	updateStat("isVisited",  ".visited-no", ".visited-yes", ".visited-no", "no");
+	updateStat("isLiked",  ".liked-yes", ".liked-yes", ".liked-no", "yes");
+	updateStat("isLiked",  ".liked-no", ".liked-yes", ".liked-no", "no");
 
 
 	function updateMood(mood) {

--- a/index.html
+++ b/index.html
@@ -189,26 +189,25 @@
 		$(`#${mood}`).on('click', e => {
 			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 			let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
+			let target = $(e.target).closest('.modal-mood');
 			if(data[zone][0][place]["mood"].hasOwnProperty(mood)) {
 				//If the place has MORE THAN 1 mood, then can delete. This is because if you delete all the moods from a place, it'll get lost in a limbo with no escape
 				if (Object.keys(data[zone][0][place]["mood"]).length > 1) {
 					delete data[zone][0][place]["mood"][mood];
-					$(e.target).closest('.modal-mood').removeClass('hovered');
-					$(e.target).closest('.modal-mood').css('background', 'rgba(222, 20, 20, 0.5)')
-					$(e.target).closest('.modal-mood').mouseleave(e => {
+					$(target).removeClass('hovered');
+					$(target).css('background', 'rgba(222, 20, 20, 0.5)')
+					$(target).mouseleave(e => {
 						$(e.target).removeAttr('style');
-						console.log('left')
 					})
 				} else {//If mood is 1 or less, do not delete and tell the user why he can't do that
 					$('.mood-error').css('display', 'initial')
 				}
 			} else {
 				data[zone][0][place]["mood"][mood] = 1;
-				$(e.target).closest('.modal-mood').addClass('hovered');
-				$(e.target).closest('.modal-mood').css('background', 'rgba(20, 222, 20, 0.5)')
-				$(e.target).closest('.modal-mood').mouseleave(e => {
+				$(target).addClass('hovered');
+				$(target).css('background', 'rgba(20, 222, 20, 0.5)')
+				$(target).mouseleave(e => {
 					$(e.target).removeAttr('style');
-					console.log('right')
 				})
 			}
 

--- a/index.html
+++ b/index.html
@@ -189,20 +189,32 @@
 			let zone = $(e.target).closest('.modal-content').find('#modal-place_name').attr('zone')
 			let place = $(e.target).closest('.modal-content').find('#modal-place_name').attr('place')
 			if(data[zone][0][place]["mood"].hasOwnProperty(mood)) {
-				delete data[zone][0][place]["mood"][mood];
-				$(e.target).closest('.modal-mood').removeClass('hovered');
-				$(e.target).closest('.modal-mood').css('background', 'rgba(222, 20, 20, 0.5)')
-				$(e.target).closest('.modal-mood').mouseleave(e => {
-					$(e.target).removeAttr('style');
-				})
+				//If the place has MORE THAN 1 mood, then can delete. This is because if you delete all the moods from a place, it'll get lost in a limbo with no escape
+				if (Object.keys(data[zone][0][place]["mood"]).length > 1) {
+					delete data[zone][0][place]["mood"][mood];
+					$(e.target).closest('.modal-mood').removeClass('hovered');
+					$(e.target).closest('.modal-mood').css('background', 'rgba(222, 20, 20, 0.5)')
+					$(e.target).closest('.modal-mood').mouseleave(e => {
+						$(e.target).removeAttr('style');
+						console.log('left')
+					})
+				} else {//If mood is 1 or less, do not delete and tell the user why he can't do that
+					$('.mood-error').css('display', 'initial')
+				}
 			} else {
 				data[zone][0][place]["mood"][mood] = 1;
 				$(e.target).closest('.modal-mood').addClass('hovered');
 				$(e.target).closest('.modal-mood').css('background', 'rgba(20, 222, 20, 0.5)')
 				$(e.target).closest('.modal-mood').mouseleave(e => {
 					$(e.target).removeAttr('style');
+					console.log('right')
 				})
 			}
+
+			if (Object.keys(data[zone][0][place]["mood"]).length > 1) {
+				$('.mood-error').css('display', 'none') //Hide the error message
+			}
+
 			localStorage.setItem('data', JSON.stringify(data))
 		})
 	}

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
 							<img class="gear3 spin" src="./res/img/icons/gear.png">
 						</a>
 					</div>
+					<span class="mood-error">Please select at least one mood per place.</span>
 				</p>
 			</div>
       <div class="modal-footer">

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -99,6 +99,11 @@ function setupMarkersByMood(map, mood) {//Creates and places markers based on mo
           settings.src = '/res/img/icons/settings.svg'
           $(settings).attr('data-toggle', 'modal');
           $(settings).attr('data-target', '#changeSettings');
+
+          $(settings).hover(e => { //Animate to signify click affordance
+            $(e.target).toggleClass('icon-hover')
+          })
+
           $(settings).on('click', e => {
             $('#modal-place_name').html(placesObj[place].name) //Set modal name to place clicked
             $('#modal-place_name').attr('zone', zone)

--- a/style/app.css
+++ b/style/app.css
@@ -427,3 +427,7 @@ p {
 	color: red;
 	display: none;
 }
+
+.icon-hover {
+	zoom: 1.1;
+}

--- a/style/app.css
+++ b/style/app.css
@@ -419,3 +419,11 @@ p {
 .modal-mood {
 	background: transparent;
 }
+
+.mood-error {
+	position: relative;
+	top: 50px;
+	left: 35px;
+	color: red;
+	display: none;
+}


### PR DESCRIPTION
- User cannot click to remove a mood if it's the last one of the page. In other words, each place has to have a mood (otherwise there would be no way to retrieve it)
- Fixed a regression introduced with #12 , where the modal wouldn't update correctly
- Added some UI effects: settings icon zoom on hover and greyed out placeholder icon
- Added error message for user that tries to remove the last mood of a place
- Improved eventListeners so that the hover effect doesn't get stuck